### PR TITLE
Update signin.js

### DIFF
--- a/lib/signin.js
+++ b/lib/signin.js
@@ -14,7 +14,7 @@ module.exports = async (browser, user, opts) => {
   await page.type('input[name=password]', user.password, { delay: 42 })
 
   await delay(700)
-  const [ signup ] = await page.$x('//button[contains(.,"Log in")]')
+  const [ signup ] = await page.$x('//button[@type="submit"]')
   await Promise.all([
     page.waitForNavigation(),
     signup.click({ delay: 30 })


### PR DESCRIPTION
Quick fix: Should no longer click on the "Log in with Facebook" button by mistake.

Just the same fix that it was done to signup.js before.